### PR TITLE
fix: throws Element's lifecycle rejections in the React render cycle

### DIFF
--- a/src/elements/useElement.ts
+++ b/src/elements/useElement.ts
@@ -58,7 +58,11 @@ const useElement = <
     if (bt && !element) {
       const newElement = bt.createElement(type as never, options as never);
 
-      newElement.mount(`#${id}`);
+      newElement.mount(`#${id}`).catch((mountError) => {
+        setElement(() => {
+          throw mountError;
+        });
+      });
       bt.indexElement(id, newElement);
       setLastOptions(options);
       setElement(newElement as Element);
@@ -86,7 +90,11 @@ const useElement = <
 
       if (Object.keys(optionsDifference).length) {
         setLastOptions(options);
-        element.update(optionsDifference);
+        element.update(optionsDifference).catch((updateError) => {
+          setLastOptions(() => {
+            throw updateError;
+          });
+        });
       }
     }
   }, [element, options, lastOptions]);

--- a/test/elements/useElement.test.ts
+++ b/test/elements/useElement.test.ts
@@ -18,9 +18,9 @@ describe('useElement', () => {
   let update: jest.Mock;
 
   beforeEach(() => {
-    mount = jest.fn();
+    mount = jest.fn(() => Promise.resolve());
 
-    update = jest.fn();
+    update = jest.fn(() => Promise.resolve());
     bt = {
       createElement: jest.fn().mockReturnValue({
         mount,
@@ -57,6 +57,22 @@ describe('useElement', () => {
     expect(mount).toHaveBeenCalledWith(`#${id}`);
     expect(result.current).toBeDefined();
     expect(bt.indexElement).toHaveBeenCalledWith(id, result.current);
+  });
+
+  test('should throw mount error in lifecycle', async () => {
+    const id = chance.string();
+    const type = chance.pickone<ElementType>(['card', 'text']);
+    const errorMessage = chance.string();
+
+    mount.mockRejectedValue(errorMessage);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useElement(id, type, {})
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.error).toStrictEqual(errorMessage);
   });
 
   test('should update options', () => {
@@ -134,5 +150,34 @@ describe('useElement', () => {
     });
 
     expect(update).toHaveBeenCalledTimes(4);
+  });
+
+  test('should throw update error in lifecycle', async () => {
+    const id = chance.string();
+    const type = chance.pickone<ElementType>(['card', 'text']);
+    const errorMessage = chance.string();
+
+    update.mockRejectedValue(errorMessage);
+
+    const { result, rerender, waitForNextUpdate } = renderHook(
+      ({ options }) => useElement(id, type, options),
+      {
+        initialProps: {
+          options: {},
+        },
+      }
+    );
+
+    // no error yet
+    expect(result.error).toBeUndefined();
+
+    // trigger error by updating (triggered options update)
+    rerender({
+      options: {
+        [chance.string()]: chance.string(),
+      },
+    });
+    await waitForNextUpdate();
+    expect(result.error).toStrictEqual(errorMessage);
   });
 });

--- a/test/elements/useElement.test.ts
+++ b/test/elements/useElement.test.ts
@@ -18,9 +18,8 @@ describe('useElement', () => {
   let update: jest.Mock;
 
   beforeEach(() => {
-    mount = jest.fn(() => Promise.resolve());
-
-    update = jest.fn(() => Promise.resolve());
+    mount = jest.fn().mockResolvedValue(undefined);
+    update = jest.fn().mockResolvedValue(undefined);
     bt = {
       createElement: jest.fn().mockReturnValue({
         mount,


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

Throws Element's lifecycle rejections `mount` and `update` at React render cycle

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
