### PR TITLE
fix: omit internal ref type from elements

### DIFF
--- a/src/elements/CardElement.tsx
+++ b/src/elements/CardElement.tsx
@@ -21,10 +21,11 @@ interface CardElementProps {
   onBlur?: ElementEventListener<CardElementEvents, 'blur'>;
   onReady?: ElementEventListener<CardElementEvents, 'ready'>;
   onKeyDown?: ElementEventListener<CardElementEvents, 'keydown'>;
-  elementRef?: ForwardedRef<ICardElement>;
 }
 
-const CardElementC: FC<CardElementProps> = ({
+const CardElementC: FC<
+  CardElementProps & { elementRef?: ForwardedRef<ICardElement> }
+> = ({
   id,
   bt,
   style,

--- a/src/elements/CardExpirationDateElement.tsx
+++ b/src/elements/CardExpirationDateElement.tsx
@@ -23,10 +23,13 @@ interface CardExpirationDateElementProps {
   onBlur?: ElementEventListener<CardExpirationDateElementEvents, 'blur'>;
   onReady?: ElementEventListener<CardExpirationDateElementEvents, 'ready'>;
   onKeyDown?: ElementEventListener<CardExpirationDateElementEvents, 'keydown'>;
-  elementRef?: ForwardedRef<ICardExpirationDateElement>;
 }
 
-const CardExpirationDateElementC: FC<CardExpirationDateElementProps> = ({
+const CardExpirationDateElementC: FC<
+  CardExpirationDateElementProps & {
+    elementRef?: ForwardedRef<ICardExpirationDateElement>;
+  }
+> = ({
   id,
   bt,
   style,

--- a/src/elements/CardNumberElement.tsx
+++ b/src/elements/CardNumberElement.tsx
@@ -25,10 +25,11 @@ interface CardNumberElementProps {
   onBlur?: ElementEventListener<CardNumberElementEvents, 'blur'>;
   onReady?: ElementEventListener<CardNumberElementEvents, 'ready'>;
   onKeyDown?: ElementEventListener<CardNumberElementEvents, 'keydown'>;
-  elementRef?: ForwardedRef<ICardNumberElement>;
 }
 
-const CardNumberElementC: FC<CardNumberElementProps> = ({
+const CardNumberElementC: FC<
+  CardNumberElementProps & { elementRef?: ForwardedRef<ICardNumberElement> }
+> = ({
   id,
   bt,
   style,

--- a/src/elements/CardVerificationCodeElement.tsx
+++ b/src/elements/CardVerificationCodeElement.tsx
@@ -28,10 +28,13 @@ interface CardVerificationCodeElementProps {
     CardVerificationCodeElementEvents,
     'keydown'
   >;
-  elementRef?: ForwardedRef<ICardVerificationCodeElement>;
 }
 
-const CardVerificationCodeElementC: FC<CardVerificationCodeElementProps> = ({
+const CardVerificationCodeElementC: FC<
+  CardVerificationCodeElementProps & {
+    elementRef?: ForwardedRef<ICardVerificationCodeElement>;
+  }
+> = ({
   id,
   bt,
   style,

--- a/src/elements/TextElement.tsx
+++ b/src/elements/TextElement.tsx
@@ -24,7 +24,6 @@ interface BaseTextElementProps {
   onBlur?: ElementEventListener<TextElementEvents, 'blur'>;
   onReady?: ElementEventListener<TextElementEvents, 'ready'>;
   onKeyDown?: ElementEventListener<TextElementEvents, 'keydown'>;
-  elementRef?: ForwardedRef<ITextElement>;
 }
 
 interface MaskedTextElementProps extends BaseTextElementProps {
@@ -39,7 +38,9 @@ interface PasswordTextElementProps extends BaseTextElementProps {
 
 type TextElementProps = MaskedTextElementProps | PasswordTextElementProps;
 
-const TextElementC: FC<TextElementProps> = ({
+const TextElementC: FC<
+  TextElementProps & { elementRef?: ForwardedRef<ITextElement> }
+> = ({
   id,
   bt,
   style,


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Omits internal `elementRef` to avoid it being accidentally set by the user

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
