### PR TITLE
feat: add value prop to elements, allow undefined apiKey w elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postinstall": "husky install"
   },
   "dependencies": {
-    "@basis-theory/basis-theory-js": "^1.49.1"
+    "@basis-theory/basis-theory-js": "^1.55.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",

--- a/src/core/useBasisTheory.ts
+++ b/src/core/useBasisTheory.ts
@@ -23,7 +23,7 @@ function useBasisTheory(
 ): UseBasisTheory<false>;
 
 function useBasisTheory(
-  apiKey: string,
+  apiKey: string | undefined,
   options: BasisTheoryInitOptionsWithElements
 ): UseBasisTheory<true>;
 

--- a/src/elements/CardElement.tsx
+++ b/src/elements/CardElement.tsx
@@ -5,6 +5,7 @@ import type {
   CardElementEvents,
   ElementEventListener,
   ElementStyle,
+  CardElementValue,
 } from '@basis-theory/basis-theory-js/types/elements';
 import type { BasisTheoryReact } from '../core';
 import { useElement } from './useElement';
@@ -16,6 +17,7 @@ interface CardElementProps {
   style?: ElementStyle;
   disabled?: boolean;
   autoComplete?: 'on' | 'off';
+  value?: CardElementValue<'static'>;
   onChange?: ElementEventListener<CardElementEvents, 'change'>;
   onFocus?: ElementEventListener<CardElementEvents, 'focus'>;
   onBlur?: ElementEventListener<CardElementEvents, 'blur'>;
@@ -31,6 +33,7 @@ const CardElementC: FC<
   style,
   disabled,
   autoComplete,
+  value,
   onReady,
   onChange,
   onFocus,
@@ -47,6 +50,7 @@ const CardElementC: FC<
       style,
       disabled,
       autoComplete,
+      value,
     },
     bt,
     elementRef

--- a/src/elements/CardExpirationDateElement.tsx
+++ b/src/elements/CardExpirationDateElement.tsx
@@ -5,6 +5,7 @@ import type {
   ElementEventListener,
   ElementStyle,
   CardExpirationDateElementEvents,
+  CardExpirationDateValue,
 } from '@basis-theory/basis-theory-js/types/elements';
 import type { BasisTheoryReact } from '../core';
 import { useElement } from './useElement';
@@ -18,6 +19,7 @@ interface CardExpirationDateElementProps {
   autoComplete?: 'on' | 'off';
   'aria-label'?: string;
   placeholder?: string;
+  value?: CardExpirationDateValue<'static'> | string;
   onChange?: ElementEventListener<CardExpirationDateElementEvents, 'change'>;
   onFocus?: ElementEventListener<CardExpirationDateElementEvents, 'focus'>;
   onBlur?: ElementEventListener<CardExpirationDateElementEvents, 'blur'>;
@@ -37,6 +39,7 @@ const CardExpirationDateElementC: FC<
   autoComplete,
   'aria-label': ariaLabel,
   placeholder,
+  value,
   onReady,
   onChange,
   onFocus,
@@ -59,6 +62,7 @@ const CardExpirationDateElementC: FC<
       autoComplete,
       'aria-label': ariaLabel,
       placeholder,
+      value,
     },
     bt,
     elementRef

--- a/src/elements/CardNumberElement.tsx
+++ b/src/elements/CardNumberElement.tsx
@@ -20,6 +20,7 @@ interface CardNumberElementProps {
   'aria-label'?: string;
   placeholder?: string;
   iconPosition?: SanitizedElementOptions['iconPosition'];
+  value?: string;
   onChange?: ElementEventListener<CardNumberElementEvents, 'change'>;
   onFocus?: ElementEventListener<CardNumberElementEvents, 'focus'>;
   onBlur?: ElementEventListener<CardNumberElementEvents, 'blur'>;
@@ -38,6 +39,7 @@ const CardNumberElementC: FC<
   'aria-label': ariaLabel,
   placeholder,
   iconPosition,
+  value,
   onReady,
   onChange,
   onFocus,
@@ -61,6 +63,7 @@ const CardNumberElementC: FC<
       'aria-label': ariaLabel,
       placeholder,
       iconPosition,
+      value,
     },
     bt,
     elementRef

--- a/src/elements/CardVerificationCodeElement.tsx
+++ b/src/elements/CardVerificationCodeElement.tsx
@@ -20,6 +20,7 @@ interface CardVerificationCodeElementProps {
   'aria-label'?: string;
   placeholder?: string;
   cardBrand?: Brand;
+  value?: string;
   onChange?: ElementEventListener<CardVerificationCodeElementEvents, 'change'>;
   onFocus?: ElementEventListener<CardVerificationCodeElementEvents, 'focus'>;
   onBlur?: ElementEventListener<CardVerificationCodeElementEvents, 'blur'>;
@@ -43,6 +44,7 @@ const CardVerificationCodeElementC: FC<
   'aria-label': ariaLabel,
   placeholder,
   cardBrand,
+  value,
   onReady,
   onChange,
   onFocus,
@@ -66,6 +68,7 @@ const CardVerificationCodeElementC: FC<
       'aria-label': ariaLabel,
       placeholder,
       cardBrand,
+      value,
     },
     bt,
     elementRef

--- a/src/elements/TextElement.tsx
+++ b/src/elements/TextElement.tsx
@@ -19,6 +19,7 @@ interface BaseTextElementProps {
   'aria-label'?: string;
   placeholder?: string;
   transform?: RegExp | [RegExp, string?];
+  value?: string;
   onChange?: ElementEventListener<TextElementEvents, 'change'>;
   onFocus?: ElementEventListener<TextElementEvents, 'focus'>;
   onBlur?: ElementEventListener<TextElementEvents, 'blur'>;
@@ -51,6 +52,7 @@ const TextElementC: FC<
   transform,
   mask,
   password,
+  value,
   onReady,
   onChange,
   onFocus,
@@ -73,6 +75,7 @@ const TextElementC: FC<
       password,
       placeholder,
       transform,
+      value,
     },
     bt,
     elementRef

--- a/src/elements/useElement.ts
+++ b/src/elements/useElement.ts
@@ -62,7 +62,7 @@ const useElement = <
       const newElement = bt.createElement(
         type as never,
         options as never
-      ) as Element;
+      ) as unknown as Element; // conversion to unknown necessary because of different value prop types
 
       elementRef.current = newElement;
 

--- a/test/elements/CardElement.test.tsx
+++ b/test/elements/CardElement.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type {
   CardElement as ICardElement,
+  CardElementValue,
   ElementStyle,
 } from '@basis-theory/basis-theory-js/types/elements';
 import { render } from '@testing-library/react';
@@ -21,6 +22,7 @@ describe('CardElement', () => {
   let style: ElementStyle;
   let disabled: boolean;
   let autoComplete: 'on' | 'off';
+  let value: CardElementValue<'static'>;
   let onReady: jest.Mock;
   let onChange: jest.Mock;
   let onFocus: jest.Mock;
@@ -38,6 +40,20 @@ describe('CardElement', () => {
     };
     disabled = chance.bool();
     autoComplete = chance.pickone(['on', 'off']);
+    value = {
+      number: chance.cc({ type: 'mc' }),
+      /* eslint-disable camelcase */
+      expiration_month: chance.integer({
+        min: 1,
+        max: 12,
+      }),
+      expiration_year: new Date().getFullYear() + 1,
+      /* eslint-enable camelcase */
+      cvc: chance.string({
+        length: 3,
+        numeric: true,
+      }),
+    };
     onReady = jest.fn();
     onChange = jest.fn();
     onFocus = jest.fn();
@@ -64,6 +80,7 @@ describe('CardElement', () => {
         onReady={onReady}
         ref={ref}
         style={style}
+        value={value}
       />
     );
 
@@ -76,6 +93,7 @@ describe('CardElement', () => {
         style,
         disabled,
         autoComplete,
+        value,
       },
       undefined,
       // eslint-disable-next-line unicorn/no-null

--- a/test/elements/CardExpirationDateElement.test.tsx
+++ b/test/elements/CardExpirationDateElement.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type {
   CardExpirationDateElement as ICardExpirationDateElement,
+  CardExpirationDateValue,
   ElementStyle,
 } from '@basis-theory/basis-theory-js/types/elements';
 import { render } from '@testing-library/react';
@@ -23,6 +24,7 @@ describe('CardExpirationDateElement', () => {
   let autoComplete: 'on' | 'off';
   let ariaLabel: string;
   let placeholder: string;
+  let value: CardExpirationDateValue<'static'>;
   let onReady: jest.Mock;
   let onChange: jest.Mock;
   let onFocus: jest.Mock;
@@ -42,7 +44,13 @@ describe('CardExpirationDateElement', () => {
     autoComplete = chance.pickone(['on', 'off']);
     ariaLabel = chance.string();
     placeholder = chance.string();
-
+    value = {
+      month: chance.integer({
+        min: 1,
+        max: 12,
+      }),
+      year: new Date().getFullYear() + 1,
+    };
     onReady = jest.fn();
     onChange = jest.fn();
     onFocus = jest.fn();
@@ -71,6 +79,7 @@ describe('CardExpirationDateElement', () => {
         placeholder={placeholder}
         ref={ref}
         style={style}
+        value={value}
       />
     );
 
@@ -86,6 +95,7 @@ describe('CardExpirationDateElement', () => {
         autoComplete,
         'aria-label': ariaLabel,
         placeholder,
+        value,
       },
       undefined,
       // eslint-disable-next-line unicorn/no-null

--- a/test/elements/CardNumberElement.test.tsx
+++ b/test/elements/CardNumberElement.test.tsx
@@ -25,6 +25,7 @@ describe('CardNumberElement', () => {
   let ariaLabel: string;
   let placeholder: string;
   let iconPosition: CreateCardNumberElementOptions['iconPosition'];
+  let value: string;
   let onReady: jest.Mock;
   let onChange: jest.Mock;
   let onFocus: jest.Mock;
@@ -45,6 +46,7 @@ describe('CardNumberElement', () => {
     ariaLabel = chance.string();
     placeholder = chance.string();
     iconPosition = chance.pickone(['left', 'right', 'none', undefined]);
+    value = chance.cc({ type: 'mc' });
 
     onReady = jest.fn();
     onChange = jest.fn();
@@ -75,6 +77,7 @@ describe('CardNumberElement', () => {
         placeholder={placeholder}
         ref={ref}
         style={style}
+        value={value}
       />
     );
 
@@ -91,6 +94,7 @@ describe('CardNumberElement', () => {
         'aria-label': ariaLabel,
         placeholder,
         iconPosition,
+        value,
       },
       undefined,
       // eslint-disable-next-line unicorn/no-null

--- a/test/elements/CardVerificationCodeElement.test.tsx
+++ b/test/elements/CardVerificationCodeElement.test.tsx
@@ -26,6 +26,7 @@ describe('CardVerificationCodeElement', () => {
   let ariaLabel: string;
   let placeholder: string;
   let cardBrand: Brand;
+  let value: string;
   let onReady: jest.Mock;
   let onChange: jest.Mock;
   let onFocus: jest.Mock;
@@ -45,6 +46,7 @@ describe('CardVerificationCodeElement', () => {
     autoComplete = chance.pickone(['on', 'off']);
     ariaLabel = chance.string();
     placeholder = chance.string();
+    value = chance.string();
 
     cardBrand = chance.pickone<Brand>([...CARD_BRANDS]);
     onReady = jest.fn();
@@ -76,6 +78,7 @@ describe('CardVerificationCodeElement', () => {
         placeholder={placeholder}
         ref={ref}
         style={style}
+        value={value}
       />
     );
 
@@ -92,6 +95,7 @@ describe('CardVerificationCodeElement', () => {
         'aria-label': ariaLabel,
         placeholder,
         cardBrand,
+        value,
       },
       undefined,
       // eslint-disable-next-line unicorn/no-null

--- a/test/elements/TextElement.test.tsx
+++ b/test/elements/TextElement.test.tsx
@@ -26,6 +26,7 @@ describe('TextElement', () => {
   let mask: (RegExp | string)[];
   let placeholder: string;
   let transform: RegExp;
+  let value: string;
   let onReady: jest.Mock;
   let onChange: jest.Mock;
   let onFocus: jest.Mock;
@@ -54,6 +55,7 @@ describe('TextElement', () => {
     );
     placeholder = chance.string();
     transform = chance.pickone([/\d/u, /./u]);
+    value = chance.string();
 
     onReady = jest.fn();
     onChange = jest.fn();
@@ -86,6 +88,7 @@ describe('TextElement', () => {
         ref={ref}
         style={style}
         transform={transform}
+        value={value}
       />
     );
 
@@ -104,6 +107,7 @@ describe('TextElement', () => {
         password,
         placeholder,
         transform,
+        value,
       },
       undefined,
       // eslint-disable-next-line unicorn/no-null

--- a/yarn.lock
+++ b/yarn.lock
@@ -1465,10 +1465,10 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@basis-theory/basis-theory-js@^1.49.1":
-  version "1.49.1"
-  resolved "https://registry.npmjs.org/@basis-theory/basis-theory-js/-/basis-theory-js-1.49.1.tgz"
-  integrity sha512-j1iwntCD45UlN3VGcrEtgderTJSk4Zn+mW6ATcLZ1f7okVJnIoREyvnFYtSpxNnwMFKFKTGbGQhT9CIh3Lfusw==
+"@basis-theory/basis-theory-js@^1.55.0":
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/@basis-theory/basis-theory-js/-/basis-theory-js-1.55.0.tgz#c0dab05a55ab437338dd82365ebb4ca70c8db699"
+  integrity sha512-mfhuvyPG6cETidd11AkU5ejN/Lf/2QWfpFdgFZZE794Zgvklj2RQmZneamtJZ35iU9T7vMwxTZLGxPGS2y7Qyw==
   dependencies:
     axios "^0.21.2"
     camelcase-keys "^6.2.2"


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds `value` prop to Elements
- Allow using `undefined` apiKey when using Elements to avoid casting env vars to `any`

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
