### PR TITLE
fix: bump btjs, export btjs types, fix cardBrand

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postinstall": "husky install"
   },
   "dependencies": {
-    "@basis-theory/basis-theory-js": "^1.55.0"
+    "@basis-theory/basis-theory-js": "^1.62.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",

--- a/src/elements/CardVerificationCodeElement.tsx
+++ b/src/elements/CardVerificationCodeElement.tsx
@@ -19,7 +19,7 @@ interface CardVerificationCodeElementProps {
   autoComplete?: 'on' | 'off';
   'aria-label'?: string;
   placeholder?: string;
-  cardBrand?: Brand;
+  cardBrand?: Brand | string;
   value?: string;
   onChange?: ElementEventListener<CardVerificationCodeElementEvents, 'change'>;
   onFocus?: ElementEventListener<CardVerificationCodeElementEvents, 'focus'>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,10 +25,4 @@ type BasisTheoryReact<Elements extends boolean = boolean> =
 
 export type { GetElement, ElementMapper, BasisTheoryReact };
 
-export type {
-  CardElement,
-  TextElement,
-  CardExpirationDateElement,
-  CardVerificationCodeElement,
-  CardNumberElement,
-} from '@basis-theory/basis-theory-js/types/elements';
+export * from '@basis-theory/basis-theory-js/types/elements';

--- a/test/elements/CardVerificationCodeElement.test.tsx
+++ b/test/elements/CardVerificationCodeElement.test.tsx
@@ -25,7 +25,7 @@ describe('CardVerificationCodeElement', () => {
   let autoComplete: 'on' | 'off';
   let ariaLabel: string;
   let placeholder: string;
-  let cardBrand: Brand;
+  let cardBrand: Brand | string;
   let value: string;
   let onReady: jest.Mock;
   let onChange: jest.Mock;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1465,10 +1465,10 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@basis-theory/basis-theory-js@^1.55.0":
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/@basis-theory/basis-theory-js/-/basis-theory-js-1.55.0.tgz#c0dab05a55ab437338dd82365ebb4ca70c8db699"
-  integrity sha512-mfhuvyPG6cETidd11AkU5ejN/Lf/2QWfpFdgFZZE794Zgvklj2RQmZneamtJZ35iU9T7vMwxTZLGxPGS2y7Qyw==
+"@basis-theory/basis-theory-js@^1.62.1":
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/@basis-theory/basis-theory-js/-/basis-theory-js-1.62.1.tgz#f6cb25226fd3af0f7df6b76cef5ac22e2a28f343"
+  integrity sha512-rrwB0SPUrc/xEO6VBFIctzXuAFao21PEfS5cvFtAvFgVp6TxgAOqXwcpvPGWD/4MsK+COcUTaO2urzfWqlbYVw==
   dependencies:
     axios "^0.21.2"
     camelcase-keys "^6.2.2"


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Bumps btJS
- Exports all elements types from BTjs
- Make so `cardBrand` accepts a string to avoid typescript issues

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
