### PR TITLE
fix/BasisTheoryReact initializing multiple times when rerender

### DIFF
--- a/src/core/useBasisTheory.ts
+++ b/src/core/useBasisTheory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import type {
   BasisTheoryInitOptionsWithElements,
   BasisTheoryInitOptionsWithoutElements,
@@ -35,13 +35,15 @@ function useBasisTheory(
     | BasisTheoryInitOptionsWithoutElements
 ): UseBasisTheory<boolean> {
   const [state, setState] = useState<UseBasisTheory<boolean>>({});
+  const isLoading = useRef(false);
 
   const { bt: btFromContext } = useBasisTheoryFromContext();
 
   useEffect(() => {
     (async (): Promise<void> => {
-      if (!state.bt && apiKey && !state.error) {
+      if (!state.bt && apiKey && !state.error && !isLoading.current) {
         try {
+          isLoading.current = true;
           const bt = (await new BasisTheoryReact().init(
             apiKey,
             options as BasisTheoryInitOptionsWithElements &
@@ -55,6 +57,8 @@ function useBasisTheory(
           setState({
             error: error as Error,
           });
+        } finally {
+          isLoading.current = false;
         }
       }
     })();


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

BasisTheoryReact initializing multiple times when rerender.
This is because the initialization is async and can take time, and meanwhile the hook can trigger again.
The solution is to add isLoading indicator.

-

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
